### PR TITLE
Sanitize email sender parameter

### DIFF
--- a/mailordie.php
+++ b/mailordie.php
@@ -74,7 +74,7 @@ if (!empty($spam_filter))
 if (empty($_GET['sender']))
 	$sender = 'Anonymous';
 else
-	$sender = trim($_GET['sender']);
+	$sender = filter_input(INPUT_GET, 'sender', FILTER_SANITIZE_EMAIL);
 if (empty($_GET['subject']))
 	$subject = 'No subject';
 else


### PR DESCRIPTION
With only $_GET, sender may contain carriage returns and other headers (to/cc) opening your box as a spam relay.